### PR TITLE
fix: :bug: Malformed URL on PR open event

### DIFF
--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -13,6 +13,6 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
-      - uses: LemLib/pros-build@v1.0.0
+      - uses: LemLib/pros-build@https://github.com/LemLib/Gamepad/actions/runs/9214344483/job/25350366702?pr=3
         with:
           library-path: gamepad

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -13,6 +13,6 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
-      - uses: LemLib/pros-build@https://github.com/LemLib/Gamepad/actions/runs/9214344483/job/25350366702?pr=3
+      - uses: LemLib/pros-build@e0f3251974c2f5b044b8e5d8665db7cfcb5dfad7
         with:
           library-path: gamepad


### PR DESCRIPTION
see for error: https://github.com/LemLib/Gamepad/actions/runs/9214344483/job/25350366702?pr=3

This should fix it by setting the `inputs.repository` context to `github.repository` by default, and therefore ensuring the URL has the correct repository.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: a0f62b8f361ad906d17a7f0f0328370aadd9eec5 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/Gamepad/actions/runs/9215671838)
- via manual download: [gamepad@0.0.1+a0f62b.zip](https://nightly.link/LemLib/Gamepad/actions/artifacts/1532924916.zip)
- via PROS Integrated Terminal: 
 ```
curl -o gamepad@0.0.1+a0f62b.zip https://nightly.link/LemLib/Gamepad/actions/artifacts/1532924916.zip;
pros c fetch gamepad@0.0.1+a0f62b.zip;
pros c apply gamepad@0.0.1+a0f62b;
rm gamepad@0.0.1+a0f62b.zip;
```